### PR TITLE
Fix runserver crash (urls.py) + allowed hosts

### DIFF
--- a/Diskuss/mypp/urls.py
+++ b/Diskuss/mypp/urls.py
@@ -5,7 +5,7 @@ from . import views
 from django.conf import settings #add this
 from django.conf.urls.static import static #add this
 #from inqu.views import CreateCheckoutSessionView
-from django.conf.urls import url
+from django.urls import re_path as url
 
 from django.views.static import serve
 

--- a/Diskuss/myproject/settings.py
+++ b/Diskuss/myproject/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = 'django-insecure-o(xtfs(ii1*de86x6c1qx@pau7yi)y%23w8)&a)i9f6p$tt$e3
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['127.0.0.1','']
+ALLOWED_HOSTS = ['127.0.0.1','*']
 
 
 # Application definition


### PR DESCRIPTION
Updated to work with modern django versions.